### PR TITLE
Make compatible with VsVim, user can search for segments longer than one char, smartcase search.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+*.vs/
+*.cr/

--- a/EasyMotion/IEasyMotionUtil.cs
+++ b/EasyMotion/IEasyMotionUtil.cs
@@ -38,10 +38,10 @@ namespace EasyMotion
         EasyMotionState State { get; }
 
         /// <summary>
-        /// During the LookingForDecision state this will be the character which 
+        /// During the LookingForDecision state this will be the character/string which 
         /// the user has decided to make an easy motion for 
         /// </summary>
-        char TargetChar { get; }
+        string Target { get; }
 
         event EventHandler StateChanged;
 
@@ -49,7 +49,7 @@ namespace EasyMotion
 
         void ChangeToLookingForChar();
 
-        void ChangeToLookingForDecision(char target);
+        void ChangeToLookingForDecision(string target);
 
         void ChangeToLookingCharNotFound();
     }

--- a/EasyMotion/Implementation/Adornment/EasyMotionAdornmentController.cs
+++ b/EasyMotion/Implementation/Adornment/EasyMotionAdornmentController.cs
@@ -157,6 +157,7 @@ namespace EasyMotion.Implementation.Adornment
             }
 
             _wpfTextView.Caret.MoveTo(point);
+            System.Windows.Forms.SendKeys.Send ("{ESC}"); 
             return true;
         }
     }

--- a/EasyMotion/Implementation/Adornment/EasyMotionAdornmentController.cs
+++ b/EasyMotion/Implementation/Adornment/EasyMotionAdornmentController.cs
@@ -105,9 +105,10 @@ namespace EasyMotion.Implementation.Adornment
             for (int i = startPoint.Position; i < endPoint.Position; i++)
             {
                 var point = new SnapshotPoint(snapshot, i);
+            var ignoreCase = _easyMotionUtil.Target.ToLowerInvariant () == _easyMotionUtil.Target; //smartcase
+            var target = ignoreCase ? _easyMotionUtil.Target.ToLowerInvariant () : _easyMotionUtil.Target;
 
-                if (Char.ToLower(point.GetChar()) == Char.ToLower(_easyMotionUtil.TargetChar) && navigateIndex < NavigationKeys.Length)
-                {
+                if ((ignoreCase ? span.GetText ().ToLowerInvariant () : span.GetText ()) == target && navigateIndex < NavigationKeys.Length) {
                     string key = NavigationKeys[navigateIndex];
                     navigateIndex++;
                     AddNavigateToPoint(textViewLines, point, key);

--- a/EasyMotion/Implementation/Adornment/EasyMotionAdornmentController.cs
+++ b/EasyMotion/Implementation/Adornment/EasyMotionAdornmentController.cs
@@ -113,6 +113,7 @@ namespace EasyMotion.Implementation.Adornment
                     navigateIndex++;
                     AddNavigateToPoint(textViewLines, point, key);
                 }
+                if (navigateIndex < NavigationKeys.Length == false) break;//don't search further, as I won't use them anyway
             }
 
             if (navigateIndex == 0)

--- a/EasyMotion/Implementation/Adornment/EasyMotionAdornmentController.cs
+++ b/EasyMotion/Implementation/Adornment/EasyMotionAdornmentController.cs
@@ -57,10 +57,10 @@ namespace EasyMotion.Implementation.Adornment {
         {
             if (_easyMotionUtil.State == EasyMotionState.LookingForDecision)
             {
+                AddAdornments ();
             }
             else
             {
-                AddAdornments ();
                 _adornmentLayer.RemoveAdornmentsByTag (_tag);
             }
         }

--- a/EasyMotion/Implementation/EasyMotionUtil/EasyMotionUtil.cs
+++ b/EasyMotion/Implementation/EasyMotionUtil/EasyMotionUtil.cs
@@ -11,14 +11,14 @@ namespace EasyMotion.Implementation.EasyMotionUtil
     {
         private readonly ITextView _textView;
         private EasyMotionState _state;
-        private char _targetChar;
+        private string _targetChar;
 
         public EasyMotionState State
         {
             get { return _state; }
         }
 
-        public char TargetChar
+        public string Target
         {
             get { return _targetChar; }
         }
@@ -39,18 +39,18 @@ namespace EasyMotion.Implementation.EasyMotionUtil
         public void ChangeToDisabled()
         {
             _state = EasyMotionState.Disabled;
-            _targetChar = (char)0;
+            _targetChar = String.Empty;
             RaiseStateChanged();
         }
 
         public void ChangeToLookingForChar()
         {
             _state = EasyMotionState.LookingForChar;
-            _targetChar = (char)0;
+            _targetChar = String.Empty;
             RaiseStateChanged();
         }
 
-        public void ChangeToLookingForDecision(char target)
+        public void ChangeToLookingForDecision(string target)
         {
             _state = EasyMotionState.LookingForDecision;
             _targetChar = target;
@@ -65,11 +65,7 @@ namespace EasyMotion.Implementation.EasyMotionUtil
 
         private void RaiseStateChanged()
         {
-            var list = StateChanged;
-            if (list != null)
-            {
-                list(this, EventArgs.Empty);
-            }
+            StateChanged?.Invoke (this, EventArgs.Empty);
         }
     }
 }

--- a/EasyMotion/Implementation/KeyProcessing/EasyMotionKeyProcessor.cs
+++ b/EasyMotion/Implementation/KeyProcessing/EasyMotionKeyProcessor.cs
@@ -8,71 +8,77 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.VisualStudio.Text.Editor;
 
-namespace EasyMotion.Implementation.KeyProcessing
-{
-    internal sealed class EasyMotionKeyProcessor : KeyProcessor
-    {
+namespace EasyMotion.Implementation.KeyProcessing {
+    internal sealed class EasyMotionKeyProcessor : KeyProcessor {
         private readonly IEasyMotionUtil _easyMotionUtil;
         private readonly IEasyMotionNavigator _easyMotionNavigator;
 
-        internal EasyMotionKeyProcessor(IEasyMotionUtil easyMotionUtil, IEasyMotionNavigator easyMotionNavigator)
-        {
+        internal EasyMotionKeyProcessor (IEasyMotionUtil easyMotionUtil, IEasyMotionNavigator easyMotionNavigator) {
             _easyMotionUtil = easyMotionUtil;
             _easyMotionNavigator = easyMotionNavigator;
         }
 
-        public override void TextInput(TextCompositionEventArgs args)
-        {
-            base.TextInput(args);
+        private int _CharsToLookFor { get; set; } = 1;
+        private string _UserInput { get; set; } = String.Empty;
 
-            switch (_easyMotionUtil.State)
-            {
+        public override void TextInput (TextCompositionEventArgs args) {
+            base.TextInput (args);
+
+            switch (_easyMotionUtil.State) { 
                 case EasyMotionState.Disabled:
                     // Nothing to do here 
                     break;
                 case EasyMotionState.LookingForChar:
                 case EasyMotionState.LookingCharNotFound:
-                    TextInputLookingForChar(args);
+                    TextInputLookingForChar (args);
                     break;
                 case EasyMotionState.LookingForDecision:
-                    TextInputLookingForDecision(args);
+                    TextInputLookingForDecision (args);
                     break;
                 default:
-                    Debug.Assert(false);
+                    Debug.Assert (false);
                     break;
             }
         }
 
-        public override void KeyUp(KeyEventArgs args)
-        {
-            base.KeyUp(args);
+        public override void KeyUp (KeyEventArgs args) {
+            base.KeyUp (args);
 
-            if (args.Key == Key.Escape && _easyMotionUtil.State != EasyMotionState.Disabled)
-            {
-                _easyMotionUtil.ChangeToDisabled();
+            if (args.Key == Key.Escape && _easyMotionUtil.State != EasyMotionState.Disabled) {
+                _easyMotionUtil.ChangeToDisabled ();
+                ClearSearch ();
+            }
+            
+        }
+
+        public override void KeyDown (KeyEventArgs args) {
+            base.KeyDown (args);
+            //if handled in KeyUp and invoked via <Space><Space> from VSVim single KeyUp event would be triggered (for the last <Space> release)
+            if (args.Key == Key.Space && _easyMotionUtil.State == EasyMotionState.LookingForChar) {
+                _CharsToLookFor++;
             }
         }
 
-        private void TextInputLookingForChar(TextCompositionEventArgs args)
-        {
-            if (args.Text.Length == 1)
-            {
-                _easyMotionUtil.ChangeToLookingForDecision(args.Text[0]);
-                args.Handled = true;
+        private void TextInputLookingForChar (TextCompositionEventArgs args) {
+            _UserInput += args.Text.Substring (args.Text.Length - 1, 1);
+            if (_UserInput.Length == _CharsToLookFor) {
+                _easyMotionUtil.ChangeToLookingForDecision (_UserInput);
+                ClearSearch ();
             }
+            args.Handled = true;
         }
 
-        private void TextInputLookingForDecision(TextCompositionEventArgs args)
-        {
-            if (args.Text.Length > 0)
-            {
-                if (_easyMotionNavigator.NavigateTo(args.Text))
-                {
-                    _easyMotionUtil.ChangeToDisabled();
-                }
-                else
-                {
-                    SystemSounds.Beep.Play();
+        private void ClearSearch () {
+            _UserInput = String.Empty;
+            _CharsToLookFor = 1;
+        }
+
+        private void TextInputLookingForDecision (TextCompositionEventArgs args) {
+            if (args.Text.Length > 0) {
+                if (_easyMotionNavigator.NavigateTo (args.Text)) {
+                    _easyMotionUtil.ChangeToDisabled ();
+                } else {
+                    SystemSounds.Beep.Play ();
                 }
 
                 args.Handled = true;

--- a/EasyMotion/Implementation/KeyProcessing/EasyMotionKeyProcessor.cs
+++ b/EasyMotion/Implementation/KeyProcessing/EasyMotionKeyProcessor.cs
@@ -24,7 +24,7 @@ namespace EasyMotion.Implementation.KeyProcessing {
         public override void TextInput (TextCompositionEventArgs args) {
             base.TextInput (args);
 
-            switch (_easyMotionUtil.State) { 
+            switch (_easyMotionUtil.State) {
                 case EasyMotionState.Disabled:
                     // Nothing to do here 
                     break;
@@ -57,13 +57,19 @@ namespace EasyMotion.Implementation.KeyProcessing {
             if (args.Key == Key.Space && _easyMotionUtil.State == EasyMotionState.LookingForChar) {
                 _CharsToLookFor++;
             }
+            //handles user backspacing his search query; this is required because query can be longer than one char
+            if (args.Key == Key.Back && _easyMotionUtil.State == EasyMotionState.LookingForChar || _easyMotionUtil.State ==  EasyMotionState.LookingCharNotFound) {
+                if (_UserInput.Length > 0) _UserInput = _UserInput.Substring (0, _UserInput.Length - 1);
+            }
         }
 
         private void TextInputLookingForChar (TextCompositionEventArgs args) {
-            _UserInput += args.Text.Substring (args.Text.Length - 1, 1);
-            if (_UserInput.Length == _CharsToLookFor) {
-                _easyMotionUtil.ChangeToLookingForDecision (_UserInput);
-                ClearSearch ();
+            if (args.Text.Length > 0) {
+                _UserInput += args.Text.Substring (args.Text.Length - 1, 1);
+                if (_UserInput.Length == _CharsToLookFor) {
+                    _easyMotionUtil.ChangeToLookingForDecision (_UserInput);
+                    ClearSearch ();
+                }
             }
             args.Handled = true;
         }

--- a/EasyMotion/Implementation/Margin/EasyMotionMarginController.cs
+++ b/EasyMotion/Implementation/Margin/EasyMotionMarginController.cs
@@ -36,7 +36,7 @@ namespace EasyMotion.Implementation.Margin
                     break;
                 case EasyMotionState.LookingForChar:
                     _control.Visibility = Visibility.Visible;
-                    _control.StatusLine = "Type the character you want to search for";
+                    _control.StatusLine = "Type the character you want to search for or press <Space> to look for string (length=2)";
                     break;
                 case EasyMotionState.LookingForDecision:
                     _control.Visibility = Visibility.Visible;
@@ -44,7 +44,7 @@ namespace EasyMotion.Implementation.Margin
                     break;
                 case EasyMotionState.LookingCharNotFound:
                     _control.Visibility = Visibility.Visible;
-                    _control.StatusLine = string.Format("Character '{0}' not found. Type the character you want to search for", _easyMotionUtil.TargetChar);
+                    _control.StatusLine = string.Format("String '{0}' not found. Type the character you want to search for", _easyMotionUtil.Target);
                     break;
                 default:
                     Debug.Assert(false);

--- a/EasyMotion/Properties/AssemblyInfo.cs
+++ b/EasyMotion/Properties/AssemblyInfo.cs
@@ -29,8 +29,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion ("1.1.0.0")]
+[assembly: AssemblyFileVersion ("1.1.0.0")]
 
 
 

--- a/EasyMotion/ReleaseNotes.txt
+++ b/EasyMotion/ReleaseNotes.txt
@@ -1,1 +1,4 @@
-﻿30-Mar-2017 v1.0.2 - Upgraded to support VS2017
+﻿2017-??-?? v1.1.0 - Hack to work with VsVim (Send ESC keystroke after navigation); Add command to navigate by two letters
+
+30-Mar-2017 v1.0.2 - Upgraded to support VS2017
+

--- a/EasyMotion/ReleaseNotes.txt
+++ b/EasyMotion/ReleaseNotes.txt
@@ -1,4 +1,8 @@
-﻿2017-??-?? v1.1.0 - Hack to work with VsVim (Send ESC keystroke after navigation); Add command to navigate by two letters
+﻿2017-??-?? v1.1.0  
+	Hack to work with VsVim (Send ESC keystroke after navigation)
+	User can search for arbitrary length strings by pressing space (single press => look for two letter segment)
+	Use smartcase when searching for segment (if query contains uppercase letter, do not ignore case)
 
-30-Mar-2017 v1.0.2 - Upgraded to support VS2017
+30-Mar-2017 v1.0.2
+	Upgraded to support VS2017
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The editor adds a status line to let you know it's ready to search.  Type 'C' as
 
 ![Example Step 3](/images/example3.png)
 
-The editor will replace all occurences of 'C' with a new letter (A-Z).  At this point if you type any of the letters the caret will be moved to that location.  In this case you type 'I' to move to the correct occurence of 'C'
+The editor will replace all occurrences of 'C' with a new letter (A-Z).  At this point if you type any of the letters the caret will be moved to that location.  In this case you type 'I' to move to the correct occurrence of 'C'
 
 ![Example Step 4](/images/example4.png)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,14 @@ EasyMotion
 
 A vim / [sublime](https://github.com/tednaleid/sublime-EasyMotion) EasyMotion clone for Visual Studio. 
 
-## Searching Example
+
+* You can search for segments longer than one char by pressing space. Each space increments segment length by one.
+
+* If you query contains uppercase characters, search won't ignore case.
+
+* Compatible with [VsVim](https://github.com/jaredpar/VsVim)
+
+## Searching Example (single character)
 The caret is at the end of the using block and you want to move it to the 'C' in 'Console.WriteLine.  
 
 ![Example Step 1](/images/example1.png)
@@ -22,8 +29,8 @@ The editor will replace all occurrences of 'C' with a new letter (A-Z).  At this
 
 The caret is now at the start of 'Console.WriteLine' as we wanted at the start
 
-You can search for segments longer than one char by pressing space. Each space increments segment length by one.
-If you query contains uppercase characters, search won't ignore case.
-Compatible with [VsVim](https://github.com/jaredpar/VsVim)
+
+
+
 
 

--- a/README.md
+++ b/README.md
@@ -22,4 +22,8 @@ The editor will replace all occurrences of 'C' with a new letter (A-Z).  At this
 
 The caret is now at the start of 'Console.WriteLine' as we wanted at the start
 
+You can search for segments longer than one char by pressing space. Each space increments segment length by one.
+If you query contains uppercase characters, search won't ignore case.
+Compatible with [VsVim](https://github.com/jaredpar/VsVim)
+
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,9 @@
 
 configuration: Debug
 
+before_build:
+  - nuget restore
+
 build:
   project: EasyMotion.sln
   verbosity: minimal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,10 @@
 
 configuration: Debug
+image: Visual Studio 2017
 
 before_build:
   - nuget restore
-
+  
 build:
   project: EasyMotion.sln
   verbosity: minimal


### PR DESCRIPTION
Fixes https://github.com/jaredpar/VsVim/issues/1839 and #3  using
` System.Windows.Forms.SendKeys.Send ("{ESC}")`
which of course nobody gonna like, but as those issues where left unfixed for long time it seems reasonable hack.

User can search for segments longer than one char.
Use smartcase for searching.

Sorry for code reformatting.