### PR TITLE
Attempt on multi-adornment support, when single-character movements are not covering all possible moves

### DIFF
--- a/EasyMotion/Implementation/Adornment/EasyMotionAdornmentController.cs
+++ b/EasyMotion/Implementation/Adornment/EasyMotionAdornmentController.cs
@@ -15,8 +15,26 @@ namespace EasyMotion.Implementation.Adornment
 {
     internal sealed class EasyMotionAdornmentController : IEasyMotionNavigator
     {
-        private static readonly string[] NavigationKeys =
-            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        private static string[] GenerateNavigationMultiKeys()
+        {
+            const string alphabet = "abcdefghijklmnopqrstuvwxyz";
+            string[] s = new string[alphabet.Length * alphabet.Length];
+            int k = 0;
+            for (int i = 0; i < alphabet.Length; i++)
+            {
+                for (int j = 0; j < alphabet.Length; j++)
+                {
+                    char[] letters = { alphabet[i], alphabet[j] };
+                    s[k] = new string(letters);
+                    k++;
+                }
+            }
+            return s;
+        }
+
+        private static readonly string[] NavigationMultiKeys = GenerateNavigationMultiKeys();
+        private static readonly string[] NavigationSingleKeys =
+            "abcdefghijklmnopqrstuvwxyz"
             .Select(x => x.ToString())
             .ToArray();
 
@@ -102,6 +120,19 @@ namespace EasyMotion.Implementation.Adornment
             var endPoint = textViewLines.LastVisibleLine.End;
             var snapshot = startPoint.Snapshot;
             int navigateIndex = 0;
+
+            for (int i = startPoint.Position; i < endPoint.Position; i++)
+            {
+                var point = new SnapshotPoint(snapshot, i);
+                if (Char.ToLower(point.GetChar()) == Char.ToLower(_easyMotionUtil.TargetChar))
+                {
+                    navigateIndex++;
+                }
+            }
+
+            string[] NavigationKeys = navigateIndex < NavigationSingleKeys.Length ? NavigationSingleKeys : NavigationMultiKeys;
+            navigateIndex = 0;
+
             for (int i = startPoint.Position; i < endPoint.Position; i++)
             {
                 var point = new SnapshotPoint(snapshot, i);

--- a/EasyMotion/Implementation/KeyProcessing/EasyMotionKeyProcessor.cs
+++ b/EasyMotion/Implementation/KeyProcessing/EasyMotionKeyProcessor.cs
@@ -14,6 +14,7 @@ namespace EasyMotion.Implementation.KeyProcessing
     {
         private readonly IEasyMotionUtil _easyMotionUtil;
         private readonly IEasyMotionNavigator _easyMotionNavigator;
+        private System.Text.StringBuilder _easyMotionLettersAccumulator = new System.Text.StringBuilder();
 
         internal EasyMotionKeyProcessor(IEasyMotionUtil easyMotionUtil, IEasyMotionNavigator easyMotionNavigator)
         {
@@ -49,6 +50,7 @@ namespace EasyMotion.Implementation.KeyProcessing
 
             if (args.Key == Key.Escape && _easyMotionUtil.State != EasyMotionState.Disabled)
             {
+                //_userInput = string.Empty;
                 _easyMotionUtil.ChangeToDisabled();
             }
         }
@@ -58,6 +60,7 @@ namespace EasyMotion.Implementation.KeyProcessing
             if (args.Text.Length == 1)
             {
                 _easyMotionUtil.ChangeToLookingForDecision(args.Text[0]);
+                _easyMotionLettersAccumulator.Clear();
                 args.Handled = true;
             }
         }
@@ -66,7 +69,8 @@ namespace EasyMotion.Implementation.KeyProcessing
         {
             if (args.Text.Length > 0)
             {
-                if (_easyMotionNavigator.NavigateTo(args.Text))
+                _easyMotionLettersAccumulator.Append(args.Text);
+                if (_easyMotionNavigator.NavigateTo(_easyMotionLettersAccumulator.ToString()))
                 {
                     _easyMotionUtil.ChangeToDisabled();
                 }


### PR DESCRIPTION
Attempt on multi-adornment support, when single-character movements are not covering all possible moves.  
Used for a case when number of places to go to  exceeds number of available single-character movements.
In that case  multi-character movements are displayed. 
Here is how it looks like (visible text contained more than 22 'x' characters, so multichar mode is activated) :
![multichar](https://user-images.githubusercontent.com/783812/27074739-af7bfdc2-5030-11e7-8368-30b5e66fb2d9.png)
