### PR TITLE
Upgraded to install and run on VS2019

### DIFF
--- a/EasyMotion/ReleaseNotes.txt
+++ b/EasyMotion/ReleaseNotes.txt
@@ -1,2 +1,2 @@
-﻿05-May-2019 v1.0.3 - Upgraded to install on VS2019
+﻿05-May-2020 v1.0.3 - Upgraded to install on VS2019
 30-Mar-2017 v1.0.2 - Upgraded to support VS2017

--- a/EasyMotion/ReleaseNotes.txt
+++ b/EasyMotion/ReleaseNotes.txt
@@ -1,1 +1,2 @@
-﻿30-Mar-2017 v1.0.2 - Upgraded to support VS2017
+﻿05-May-2019 v1.0.3 - Upgraded to install on VS2019
+30-Mar-2017 v1.0.2 - Upgraded to support VS2017

--- a/EasyMotion/source.extension.vsixmanifest
+++ b/EasyMotion/source.extension.vsixmanifest
@@ -1,22 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="5bb019ad-a18e-4c86-af3c-27217853df95" Version="1.0.3" Language="en-US" Publisher="JaredPar" />
-        <DisplayName>EasyMotion</DisplayName>
-        <Description xml:space="preserve">Easy Motion clone for Visual Studio</Description>
-        <ReleaseNotes>ReleaseNotes.txt</ReleaseNotes>
-    </Metadata>
-    <Installation InstalledByMsi="false">
-        <InstallationTarget Version="[14.0,)" Id="Microsoft.VisualStudio.Community" />
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    </Dependencies>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-    </Assets>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
+  <Metadata>
+    <Identity Id="5bb019ad-a18e-4c86-af3c-27217853df95" Version="1.0.3" Language="en-US" Publisher="JaredPar" />
+    <DisplayName>EasyMotion</DisplayName>
+    <Description>Easy Motion clone for Visual Studio</Description>
+    <ReleaseNotes>ReleaseNotes.txt</ReleaseNotes>
+  </Metadata>
+  <Installation InstalledByMsi="false">
+    <InstallationTarget Version="[14.0,)" Id="Microsoft.VisualStudio.Community" />
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+  </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/EasyMotion/source.extension.vsixmanifest
+++ b/EasyMotion/source.extension.vsixmanifest
@@ -1,22 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="5bb019ad-a18e-4c86-af3c-27217853df95" Version="1.0.2" Language="en-US" Publisher="JaredPar" />
-    <DisplayName>EasyMotion</DisplayName>
-    <Description>Easy Motion clone for Visual Studio</Description>
-    <ReleaseNotes>ReleaseNotes.txt</ReleaseNotes>
-  </Metadata>
-  <Installation InstalledByMsi="false">
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-  </Assets>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
+    <Metadata>
+        <Identity Id="5bb019ad-a18e-4c86-af3c-27217853df95" Version="1.0.3" Language="en-US" Publisher="JaredPar" />
+        <DisplayName>EasyMotion</DisplayName>
+        <Description xml:space="preserve">Easy Motion clone for Visual Studio</Description>
+        <ReleaseNotes>ReleaseNotes.txt</ReleaseNotes>
+    </Metadata>
+    <Installation InstalledByMsi="false">
+        <InstallationTarget Version="[14.0,)" Id="Microsoft.VisualStudio.Community" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+    </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Simply removed the limit on installation target and Core Editor.
Should now install and run on VS2019 (and future versions, too).